### PR TITLE
Replace FlaskService with QuartService

### DIFF
--- a/elg_adapter/Dockerfile
+++ b/elg_adapter/Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3.7-slim
+FROM python:slim
 
 # Install tini and create an unprivileged user
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /sbin/tini
 RUN addgroup --gid 1001 "elg" && adduser --disabled-password --gecos "ELG User,,," --home /elg --ingroup elg --uid 1001 elg && chmod +x /sbin/tini
 
-# Copy in our app, its requirements file and the entrypoint script
-COPY --chown=elg:elg requirements.txt docker-entrypoint.sh adapter.py /elg/
-
+# Copy in just the requirements file
+COPY --chown=elg:elg requirements.txt /elg/
 
 # Everything from here down runs as the unprivileged user account
 USER elg:elg
@@ -14,8 +13,13 @@ USER elg:elg
 WORKDIR /elg
 
 # Create a Python virtual environment for the dependencies
-RUN python -mvenv venv 
+RUN python -m venv venv 
+RUN /elg/venv/bin/python -m pip install --upgrade pip
 RUN venv/bin/pip --no-cache-dir install -r requirements.txt 
+
+# Copy ini the entrypoint script and everything else our app needs
+
+COPY --chown=elg:elg docker-entrypoint.sh adapter.py /elg/
 
 ENV WORKERS=1
 

--- a/elg_adapter/Makefile
+++ b/elg_adapter/Makefile
@@ -32,7 +32,7 @@ build:
 
 
 build-model:
-	elg docker create --path ./adapter.py --classname Adapter
+	elg docker create --path ./adapter.py --classname Adapter --service_type quart
 	docker build -t techiaith/elg-adapter-deepspeech-server-cy-${MODEL_NAME} .
 
 

--- a/elg_adapter/README.md
+++ b/elg_adapter/README.md
@@ -2,7 +2,7 @@
 
 As the adapter is using the ELG python SDK, you need to have it installed. If it is not the case, run: 
 
-`$ pip install elg==0.4.5` 
+`$ pip install --upgrade elg[quart]==0.4.9` 
 
 and make sure it is accessible from your PATH. Run the following to verify: 
 

--- a/elg_adapter/adapter-transcribe.py
+++ b/elg_adapter/adapter-transcribe.py
@@ -1,14 +1,31 @@
-from elg import FlaskService
+import traceback
+
+from loguru import logger
+
+from elg import QuartService
 from elg.model import TextsResponse
+from elg.quart_service import ProcessingError
 
-import requests
 
-class Adapter(FlaskService):
+class Adapter(QuartService):
+    
+    async def process_audio(self, content):
+        try:
+            # Make the remote call
+            async with self.session.post("https://api.techiaith.org/deepspeech/transcribe/speech_to_text/", data={"soundfile": content.content}) as client_response:
+                status_code = client_response.status
+                content = await client_response.json()
+        except:
+            traceback.print_exc()
+            raise ProcessingError.InternalError('Error calling API')
 
-    def process_audio(self, content):
-        response = requests.post("https://api.techiaith.org/deepspeech/transcribe/speech_to_text/", files={"soundfile": content.content})
-        assert response.ok, response.content     
-        return TextsResponse(texts=[{"content": response.json()["text"]}])
+        if status_code >= 400:
+            # if your API returns sensible error messages you could include that
+            # instead of the generic message
+            raise ProcessingError.InternalError('Error calling API')
+        
+        logger.info("Return the text response")
+        return TextsResponse(texts=[{"content": content["text"]}])
 
-flask_service = Adapter("Adapter")
-app = flask_service.app
+service = Adapter("Adapter")
+app = service.app

--- a/elg_adapter/adapter.py
+++ b/elg_adapter/adapter.py
@@ -1,14 +1,31 @@
-from elg import FlaskService
+import traceback
+
+from loguru import logger
+
+from elg import QuartService
 from elg.model import TextsResponse
+from elg.quart_service import ProcessingError
 
-import requests
 
-class Adapter(FlaskService):
+class Adapter(QuartService):
+    
+    async def process_audio(self, content):
+        try:
+            # Make the remote call
+            async with self.session.post("https://api.techiaith.org/deepspeech/transcribe/speech_to_text/", data={"soundfile": content.content}) as client_response:
+                status_code = client_response.status
+                content = await client_response.json()
+        except:
+            traceback.print_exc()
+            raise ProcessingError.InternalError('Error calling API')
 
-    def process_audio(self, content):
-        response = requests.post("https://api.techiaith.org/deepspeech/transcribe/speech_to_text/", files={"soundfile": content.content})
-        assert response.ok, response.content     
-        return TextsResponse(texts=[{"content": response.json()["text"]}])
+        if status_code >= 400:
+            # if your API returns sensible error messages you could include that
+            # instead of the generic message
+            raise ProcessingError.InternalError('Error calling API')
+        
+        logger.info("Return the text response")
+        return TextsResponse(texts=[{"content": content["text"]}])
 
-flask_service = Adapter("Adapter")
-app = flask_service.app
+service = Adapter("Adapter")
+app = service.app

--- a/elg_adapter/docker-entrypoint.sh
+++ b/elg_adapter/docker-entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /sbin/tini -- venv/bin/gunicorn --bind=0.0.0.0:8000 "--workers=$WORKERS" --worker-tmp-dir=/dev/shm "$@" adapter:app
+exec /sbin/tini -- venv/bin/hypercorn --bind=0.0.0.0:8000 "$@" adapter:app

--- a/elg_adapter/requirements.txt
+++ b/elg_adapter/requirements.txt
@@ -1,7 +1,1 @@
-flask
-Flask
-gunicorn
-docker
-elg
-flask_json
-Flask-JSON
+elg[quart]


### PR DESCRIPTION
Make use of the new features of the latest version of the ELG python SDK:

* QuartService instead of FlaskService : allow the proxy to handle request asynchronously
* Better dependencies : `pip install elg[quart]` install everything needed for the QuartService to run
*  Bugs have been fixed